### PR TITLE
Use the provided task from the event

### DIFF
--- a/src/app/components/tasks/tasks.component.html
+++ b/src/app/components/tasks/tasks.component.html
@@ -2,6 +2,6 @@
 <app-task-item
   *ngFor="let task of tasks"
   [task]="task"
-  (onDeleteTask)="deleteTask(task)"
-  (onToggleReminder)="toggleReminder(task)"
+  (onDeleteTask)="deleteTask($event)"
+  (onToggleReminder)="toggleReminder($event)"
 ></app-task-item>


### PR DESCRIPTION
Since the `task-item` component is providing the task, it should be used instead of the looped data.
This provides more consistency and in case the event has changed any data, using the looped data won't be visible in the handlers.
Otherwise, the Task could be removed from the event emitting