### PR TITLE
Change port of json-server to 5002 because of macOS bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ npm install
 ng serve
 ```
 
-### Run the JSON server (http://localhost:5000)
+### Run the JSON server (http://localhost:5002)
 
 ```
 npm run server

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",
-    "server": "json-server --watch db.json --port 5000"
+    "server": "json-server --watch db.json --port 5002"
   },
   "private": true,
   "dependencies": {


### PR DESCRIPTION
Port 5000 for json server doesn't work on modern macOS versions because it is already assigned to [AirPlay Receiver](https://en.wikipedia.org/wiki/AirPlay#Receivers). This prevents web servers from serving on port 5000. Changing this to some other port for example to port 5002 fixes this issue.